### PR TITLE
ENH: Remove temp test fille

### DIFF
--- a/controls_doctor/_doctor.py
+++ b/controls_doctor/_doctor.py
@@ -74,6 +74,8 @@ def nfs_perf():
     {} bytes/sec. As a result, programs may be unresponsive. Contact the IT
     group.
 """.format(rate)
+    # Cleanup after ourselves, just to be nice
+    os.remove(output_path)
     return rate > THRESH, msg
 
 

--- a/controls_doctor/_doctor.py
+++ b/controls_doctor/_doctor.py
@@ -63,8 +63,8 @@ def nfs_perf():
     THRESH = 1000000
     output_path = os.path.expanduser('~/.check-doctor-dd-testfile')
     output = subprocess.check_output(
-            ['sync;', 'dd', 'if=/dev/random', 'of={}'.format(output_path),
-             'bs=1048576', 'count=1', '; sync'], stderr=subprocess.STDOUT).decode()
+            ['dd', 'if=/dev/random', 'of={}'.format(output_path),
+             'bs=1048576', 'count=1'], stderr=subprocess.STDOUT).decode()
     for line in output.split('\n'):
         if line.endswith('/s') or line.endswith('/sec'):
             rate = float(line.split()[-2])

--- a/controls_doctor/_doctor.py
+++ b/controls_doctor/_doctor.py
@@ -63,8 +63,8 @@ def nfs_perf():
     THRESH = 1000000
     output_path = os.path.expanduser('~/.check-doctor-dd-testfile')
     output = subprocess.check_output(
-            ['dd', 'if=/dev/random', 'of={}'.format(output_path),
-             'bs=1048576', 'count=1'], stderr=subprocess.STDOUT).decode()
+            ['sync;', 'dd', 'if=/dev/random', 'of={}'.format(output_path),
+             'bs=1048576', 'count=1', '; sync'], stderr=subprocess.STDOUT).decode()
     for line in output.split('\n'):
         if line.endswith('/s') or line.endswith('/sec'):
             rate = float(line.split()[-2])


### PR DESCRIPTION
Added `sync`s around the NFS write performance test using `dd`. 

NOTE: I haven't actually tested this on a real NSLS-II machine yet
(was having issues logging in remotely)